### PR TITLE
スタジオ登録後の一覧表示・登録スタジオ情報の編集削除機能・一覧と地図上マーカーとの連動

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -17,7 +17,7 @@ class SpotsController < ApplicationController
   end
 
   def create
-    @spot = @group.spots.new(content: spot_params[:content], user: current_user)
+    @spot = @group.spots.new(spot_params.merge(user: current_user))
     if @spot.save
       redirect_to group_spots_path(@group), notice: 'スタジオが登録されました'
     else
@@ -45,7 +45,7 @@ class SpotsController < ApplicationController
 
   private
 
-  def set_voice
+  def set_spot
     @group = Group.find(params[:group_id])
     @spot = @group.spots.find(params[:id])
   end
@@ -62,7 +62,7 @@ class SpotsController < ApplicationController
   end
 
   def authorize_owner!
-    @voice = @group.spots.find(params[:id])
+    @spot = @group.spots.find(params[:id])
     @group = Group.find(params[:group_id])
     unless @spot.user == current_user
       redirect_to group_voices_path(@group), alert: '操作の権限がありません'
@@ -70,6 +70,6 @@ class SpotsController < ApplicationController
   end
 
   def spot_params
-    params.require(:spot).permit(:registered_title, :address, :latitude, :longitude, :opening_hours, :phone_number, :website, :place_id)
+    params.require(:spot).permit(:registered_title, :address, :lat, :lng, :opening_hours, :phone_number, :website, :place_id)
   end
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,6 +1,6 @@
 class Spot < ApplicationRecord
   belongs_to :user
   belongs_to :group
-  validates :latitude, presence: true
-  validates :longitude, presence: true
+  validates :lat, presence: true
+  validates :lng, presence: true
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,27 +27,23 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body>
-    <div class="font-notosansjp">
-      <div class="min-h-screen w-full relative pb-12">
-        <div class="w-full">
-          <% if logged_in? %> 
-            <%= render 'shared/header' %>  
-          <% else %> 
-            <%= render 'shared/before_login_header' %> 
-        <% end %> 
-        </div>
-        <div class="my-5 relative z-0">
-          <!-- フラッシュメッセージの表示 -->
-          <%= render 'shared/flash_message' %> 
-          <%= yield %>
-        </div>
-        <div class="absolute bottom-0 w-full">
-          <!-- フッター -->
-          <%= render 'shared/footer' %>
-        </div>
-      </div>
-    </div>
+<body class="min-h-screen flex flex-col">
+    <header class="w-full">
+      <% if logged_in? %> 
+        <%= render 'shared/header' %>  
+      <% else %> 
+        <%= render 'shared/before_login_header' %> 
+      <% end %> 
+    </header>
+    <main class="flex-grow my-5">
+      <!-- フラッシュメッセージの表示 -->
+      <%= render 'shared/flash_message' %> 
+      <%= yield %>
+    </main>
+    <footer class="w-full">
+      <!-- フッター -->
+      <%= render 'shared/footer' %>
+    </footer>
   </body>
 </html>
 

--- a/app/views/spots/edit.html.erb
+++ b/app/views/spots/edit.html.erb
@@ -1,12 +1,10 @@
-<div class="text-center text-xl font-bold mt-10">プロフィール編集</div>
+<div class="text-center text-xl font-bold mt-10">スタジオ編集</div>
 
 <div class="flex flex-col items-center mt-4">
-  <%= form_with model: @user, url: profile_path do |f| %>
+  <%= form_with model: @spot, url: group_spot_path(@group) do |f| %>
     <div class="grid grid-cols-1 gap-4 justify-items-center max-w-4xl mx-auto">
-      <%= f.label :email, 'メールアドレス' %>
-      <%= f.text_area :email, rows: 1, class: "rounded-lg p-4 w-full" %>
-      <%= f.label :name, '名前' %>
-      <%= f.text_area :name, rows: 1, class: "rounded-lg p-4 w-full" %>
+      <%= f.label :registered_title, '登録タイトル' %>
+      <%= f.text_area :registered_title, rows: 1, class: "rounded-lg p-4 w-full" %>
     </div>
     <div class="flex justify-center mt-4 mx-4">
       <div class="mr-4"">

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -5,15 +5,16 @@
   <title>スタジオ一覧</title>
 </head>
 <body>
+  <div class="flex justify-center mt-4 mx-4">
+    <%= link_to "#{@group.name}:グループ詳細画面", group_path(@group),  class: "btn btn-sm btn-success" %> 
+  </div>
   <div class="flex flex-col items-center mt-4">
     <div class="text-center text-xl font-bold mt-10">スタジオ一覧</div>
     
-    <input id="address" type="textbox" class="w-2/3 mt-4 mb-4">
-    <input type="button" value="検索する" onclick="codeAddress()" class="btn btn-sm btn-success mb-4">
     <%= link_to 'スタジオ登録画面へ', new_group_spot_path(@group), class: "btn btn-sm btn-success mb-4" %>
 
-    <div id='map'></div>
-  </div>  
+  <div id="map"></div>
+
   <style>
   #map {
     height: 400px;
@@ -21,47 +22,79 @@
     margin: 0 auto;
   }
   </style>
-  </div>
+
+  <ul  class="grid grid-cols-1 justify-items-center max-w-4xl mx-auto mt-4" id="spot-list">
+    <% if @spots.present? %>
+      <% @spots.each do |spot| %>
+        <li class="bg-white shadow-md rounded-lg p-4 w-5/6 max-w-md mb-4">
+          <div class="flex justify-between items-center mt-2">
+            <div>
+              <a href="#" class="spot-link link-hover" data-index="<%= @spots.index(spot) %>"><%= spot.registered_title %></a>
+              <div class="text-sm text-gray-500 mt-2"><%= spot.address %></div>
+            </div>
+            <%= link_to '詳細', group_spot_path(@group, spot), class: "btn btn-sm btn-success my-4 mx-4" %>
+          </div>
+        </li>
+      <% end %>
+    <% else %>
+        <div>登録したスタジオが見つかりません</div>
+    <% end %>
+  </ul>
 
   <script>
-  let map
+    function initMap() {
+      let latlng = new google.maps.LatLng(35.6803997, 139.7690174); // 地図の表示初期値(東京)
+      let map = new google.maps.Map(document.getElementById('map'), {
+        zoom: 10,
+        center: latlng
+      });
+      let activeInfoWindow; // 現在開いているInfoWindowを追跡
 
-  function initMap(){
-    geocoder = new google.maps.Geocoder()
+      let markers = []; // マーカーを保存する配列
+      let infoWindows = []; // InfoWindowを保存する配列
 
-    map = new google.maps.Map(document.getElementById('map'), {
-      center: { lat: 35.6803997, lng: 139.7690174 }, //東京
-      zoom: 10,
-    });
+      <% @spots.each_with_index do |spot, index| %> 
+        (function() {
+          let markerLatLng = { lat: <%= spot.lat %>, lng: <%= spot.lng %> };
+          let marker = new google.maps.Marker({
+            position: markerLatLng,
+            map: map
+          });
+          markers.push(marker); // マーカーを配列に追加
 
-    marker = new google.maps.Marker({
-      position:  {lat: 40.7828, lng:-73.9653},
-      map: map
-    });
+          let infowindow = new google.maps.InfoWindow({
+            position: markerLatLng,
+            content: "<a href='<%= group_spot_path(@group, spot) %>' class='text-blue-600 link-hover'><%= spot.registered_title %></a>"
+          });
+          infoWindows.push(infowindow); // InfoWindowを配列に追加
 
-    const input = document.getElementById("address");
-    const autocomplete = new google.maps.places.Autocomplete(input);
-    autocomplete.bindTo("bounds", map);
-  }
+          // マーカーをクリックしたら詳細情報の吹き出しが表示される
+          marker.addListener('click', function() {
+            if (activeInfoWindow) { 
+              activeInfoWindow.close(); // 前のInfoWindowを閉じる
+            }
+            infowindow.open(map, marker); // 新しいInfoWindowを開く
+            activeInfoWindow = infowindow; // 現在開いているInfoWindowを更新
+          });
+        })();
+      <% end %>
 
+      // 一覧のタイトルをクリックすると、地図上の対象のピン上に吹き出しが表示される
+      document.querySelectorAll('.spot-link').forEach(function(link) {
+        link.addEventListener('click', function(event) {
+          event.preventDefault();
+          let index = parseInt(this.getAttribute('data-index'), 10);
+          let marker = markers[index];
+          let infowindow = infoWindows[index];
 
-  let geocoder
-
-  function codeAddress(){
-    let inputAddress = document.getElementById("address").value;
-
-    geocoder.geocode( { 'address': inputAddress}, function(results, status) {
-      if (status == 'OK') {
-        map.setCenter(results[0].geometry.location);
-        var marker = new google.maps.Marker({
-            map: map,
-            position: results[0].geometry.location
+          if (activeInfoWindow) { 
+            activeInfoWindow.close(); // 前のInfoWindowを閉じる
+          }
+          infowindow.open(map, marker); // 新しいInfoWindowを開く
+          activeInfoWindow = infowindow; // 現在開いているInfoWindowを更新
         });
-      } else {
-        alert('該当する結果がありませんでした：' + status);
-      }
-    });   
-  }
+      });
+    }
   </script>
   <script src="https://maps.googleapis.com/maps/api/js?key=<%= Rails.application.credentials.google_map_api_key %>&libraries=places&callback=initMap" async defer></script>
 </body>

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -5,15 +5,18 @@
   <title>スタジオを登録</title>
 </head>
 <body>
+  <div class="flex justify-center mt-4 mx-4">
+    <%= link_to "#{@group.name}:グループ詳細画面", group_path(@group),  class: "btn btn-sm btn-success" %> 
+  </div>
   <div class="flex flex-col items-center mt-4">
     <div class="text-center text-xl font-bold mt-10">スタジオを登録</div>
-  
-    <input id="address" type="textbox" placeholder="ピンを刺したい地名を検索" class="w-2/3 mt-4 mb-4">
+
+    <%= form_with model: @spot, url: group_spots_path(@group), class: "w-full flex flex-col items-center" do |f|  %>
+    <%= f.text_field :address, id: :address, placeholder: "ピンを刺したい地名を検索", class: "w-2/3 mb-4" %>
     <input type="button" value="①地図上にピンを刺す" onclick="codeAddress()" class="btn btn-sm btn-success mb-4">
-    <%= form_with model: @map, class: "w-full flex flex-col items-center" do |f|  %>
     <%= f.text_field :registered_title, placeholder: "登録タイトルを入力", class: "w-2/3 mb-4" %>
-    <%= f.hidden_field :latitude, id: :lat %>
-    <%= f.hidden_field :longitude, id: :lng %>
+    <%= f.hidden_field :lat, id: :lat %>
+    <%= f.hidden_field :lng, id: :lng %>
     <%= f.submit "②スタジオ一覧に登録する", class: "btn btn-sm btn-success mb-4" %>
     <% end %>
     <%= link_to "スタジオ一覧に戻る", group_spots_path(@group), class: "underline text-blue-600 mb-4"%>
@@ -74,6 +77,7 @@
      }
    });
  }
+ 
 </script>
   <script src="https://maps.googleapis.com/maps/api/js?key=<%= Rails.application.credentials.google_map_api_key %>&libraries=places&callback=initMap" async defer></script>
 </body>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,0 +1,20 @@
+<div class="flex justify-center mt-4 mx-4">
+  <%= link_to "#{@group.name}:グループ詳細画面", group_path(@group),  class: "btn btn-sm btn-success" %> 
+</div>
+<div class="text-center text-xl font-bold mt-10">登録したスタジオ詳細</div>
+<div class="flex flex-col items-center">
+  <div class="mt-4">登録タイトル</div>
+  <div class="mt-4"><%= @spot.registered_title %></div>
+  <div class="mt-4">投稿者名</div>
+  <div class="mt-4"><%= @spot.user.name %></div>
+
+  <div class="flex justify-center mt-4">
+    <div class="mr-4">
+    <%= link_to 'タイトル編集', edit_group_spot_path(@group, @spot) , class: 'btn btn-success float-right' %>
+    </div>
+    <div class="mr-4">
+    <%= link_to 'スタジオ削除', group_spot_path,  class: "btn btn-outline btn-error", data: { turbo_method: :delete, turbo_confirm: "削除しますか" }%>
+    </div>
+  </div>
+  <%= link_to "スタジオ一覧に戻る", group_spots_path(@group), class: "underline text-blue-600 my-4"%>
+</div>

--- a/db/migrate/20240718103642_rename_latitude_column_to_spot.rb
+++ b/db/migrate/20240718103642_rename_latitude_column_to_spot.rb
@@ -1,0 +1,5 @@
+class RenameLatitudeColumnToSpot < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :spots, :latitude, :lat
+  end
+end

--- a/db/migrate/20240718104012_rename_longitude_column_to_spot.rb
+++ b/db/migrate/20240718104012_rename_longitude_column_to_spot.rb
@@ -1,0 +1,5 @@
+class RenameLongitudeColumnToSpot < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :spots, :longitude, :lng
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_16_085149) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_18_104012) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,8 +52,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_085149) do
   create_table "spots", force: :cascade do |t|
     t.string "registered_title"
     t.string "address"
-    t.float "latitude", null: false
-    t.float "longitude", null: false
+    t.float "lat", null: false
+    t.float "lng", null: false
     t.string "opening_hours"
     t.string "phone_number"
     t.string "website"

--- a/test/fixtures/spots.yml
+++ b/test/fixtures/spots.yml
@@ -5,9 +5,9 @@ one:
   string: MyString
   address: MyString
   string: MyString
-  latitude: MyString
+  lat: MyString
   float: MyString
-  longitude: MyString
+  lng: MyString
   float: MyString
   opening_hours: MyString
   string: MyString
@@ -23,9 +23,9 @@ two:
   string: MyString
   address: MyString
   string: MyString
-  latitude: MyString
+  lat: MyString
   float: MyString
-  longitude: MyString
+  lng: MyString
   float: MyString
   opening_hours: MyString
   string: MyString


### PR DESCRIPTION
Closes #35 
Closes #23 

- [X] 登録ボタンを押した後
  - [X] Google Places APIを用いて、場所の詳細情報をdbに保存
  - [X] 登録した場所にピンをたてる
  - [X] ピンをクリックすると、吹き出しで場所名が表示される
  - [X] 地図下部に、登録した場所を一覧で表示
 - [X] 一覧の投稿をクリックすると、地図上に各投稿の場所が表示されるように設計

- [X] スタジオ一覧の各投稿をクリックした際に遷移する、詳細ページの設計
  - [X] 場所のタイトル_編集機能の設置
  - [X] 場所に関する詳細メモフォーム・登録ボタンの設置
  - [X] 場所に関する詳細メモ_編集機能の設置
  - [X] 一覧に登録したスタジオ_削除機能の設置


