### PR TITLE
地図機能_現在地から目的のスタジオまでの道のり表示

### DIFF
--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -62,10 +62,18 @@
             map: map
           });
           markers.push(marker); // マーカーを配列に追加
+          let googleMapsUrl = "https://www.google.com/maps/search/?api=1&query=<%= spot.lat %>,<%= spot.lng %>&query_place_id=<%= spot.place_id %>";
+          
 
           let infowindow = new google.maps.InfoWindow({
             position: markerLatLng,
-            content: "<a href='<%= group_spot_path(@group, spot) %>' class='text-blue-600 link-hover'><%= spot.registered_title %></a>"
+            content: `
+              <a href='<%= group_spot_path(@group, spot) %>' class='text-blue-600 link-hover'>
+                <%= spot.registered_title %>
+              </a><br>
+              <a href='${googleMapsUrl}' target='_blank' class='text-blue-600 link-hover'>
+                Googleマップで見る
+              </a>`
           });
           infoWindows.push(infowindow); // InfoWindowを配列に追加
 

--- a/app/views/spots/new.html.erb
+++ b/app/views/spots/new.html.erb
@@ -17,6 +17,7 @@
     <%= f.text_field :registered_title, placeholder: "登録タイトルを入力(例：初回練習)", class: "w-2/3 mb-4" %>
     <%= f.label :start_datetime, '練習開始日時', class: "font-semibold"%>
     <%= f.datetime_field :start_datetime %>
+    <%= f.hidden_field :place_id, id: :place_id %>
     <%= f.hidden_field :lat, id: :lat %>
     <%= f.hidden_field :lng, id: :lng %>
     <%= f.submit "②スタジオ一覧に登録する", class: "btn btn-sm btn-success my-4" %>
@@ -73,6 +74,7 @@
 
        document.getElementById('lat').value = results[0].geometry.location.lat();
        document.getElementById('lng').value = results[0].geometry.location.lng();
+       document.getElementById('place_id').value = results[0].place_id;
 	//情報をフォームのhidden_fieldへ送る
      } else {
        alert('該当する結果はありませんでした');


### PR DESCRIPTION
Closes #24 

- [ ] 登録したピンをクリックした際に出るモーダルに、「googleマップで表示する」ボタンを追加する(→遷移先のgoogleマップアプリで同じ場所情報を表示し、必要に応じてユーザーに経路を検索してもらう)