### PR TITLE
個人がグループ機能に投稿した内容が、自分の個人機能一覧にも表示される不具合を修正

### DIFF
--- a/app/controllers/personal_spots_controller.rb
+++ b/app/controllers/personal_spots_controller.rb
@@ -4,11 +4,11 @@ class PersonalSpotsController < ApplicationController
   before_action :set_spot, only: %i[edit update destroy]
 
   def index
-    @spots = current_user.spots.order(start_datetime: :asc)
+    @spots = current_user.spots.where(group_id: nil).order(start_datetime: :asc)
   end
 
   def show
-    @spot = current_user.spots.find(params[:id])
+    @spot = current_user.spots.where(group_id: nil).find(params[:id])
   end
 
   def new
@@ -46,7 +46,7 @@ class PersonalSpotsController < ApplicationController
   private
 
   def set_spot
-    @spot = current_user.spots.find(params[:id])
+    @spot = current_user.spots.where(group_id: nil).find(params[:id])
   end
 
   def spot_params

--- a/app/controllers/personal_summaries_controller.rb
+++ b/app/controllers/personal_summaries_controller.rb
@@ -6,11 +6,11 @@ class PersonalSummariesController < ApplicationController
   before_action :set_summary, only: %i[edit update destroy]
 
   def index
-    @summaries = current_user.summaries.order(created_at: :desc)
+    @summaries = current_user.summaries.where(group_id: nil).order(created_at: :desc)
   end
 
   def show
-    @summary = current_user.summaries.find(params[:id])
+    @summary = current_user.summaries.where(group_id: nil).find(params[:id])
     @comment = Comment.new
     @comments = @summary.comments.includes(:user).order(created_at: :desc)
   end
@@ -110,7 +110,7 @@ class PersonalSummariesController < ApplicationController
   private
 
   def set_summary
-    @summary = current_user.summaries.find(params[:id])
+    @summary = current_user.summaries.where(group_id: nil).find(params[:id])
   end
 
   def summary_params

--- a/app/controllers/personal_videos_controller.rb
+++ b/app/controllers/personal_videos_controller.rb
@@ -4,7 +4,7 @@ class PersonalVideosController < ApplicationController
   before_action :set_video, only: %i[edit update destroy]
 
   def index
-    @videos = current_user.videos.includes(:user).order(created_at: :desc)
+    @videos = current_user.videos.where(group_id: nil).order(created_at: :desc)
   end
 
   def new
@@ -42,7 +42,7 @@ class PersonalVideosController < ApplicationController
   private
 
   def set_video
-    @video = current_user.videos.find(params[:id])
+    @video = current_user.videos.where(group_id: nil).find(params[:id])
   end
 
   def video_params

--- a/app/controllers/personal_voices_controller.rb
+++ b/app/controllers/personal_voices_controller.rb
@@ -4,11 +4,11 @@ class PersonalVoicesController < ApplicationController
   before_action :set_voice, only: %i[edit update destroy]
 
   def index
-    @voices = current_user.voices.order(created_at: :desc)
+    @voices = current_user.voices.where(group_id: nil).order(created_at: :desc)
   end
 
   def show
-    @voice = current_user.voices.find(params[:id])
+    @voice = current_user.voices.where(group_id: nil).find(params[:id])
   end
 
   def edit; end
@@ -45,7 +45,7 @@ class PersonalVoicesController < ApplicationController
   private
 
   def set_voice
-    @voice = current_user.voices.find(params[:id])
+    @voice = current_user.voices.where(group_id: nil).find(params[:id])
   end
 
   def voice_params


### PR DESCRIPTION
Closes #77 

個人機能の各コントローラー内で、表示する投稿を取得する際に`where(group_id: nil)`を追加
→自分の投稿かつgroup_idが空になっている投稿のみを個人機能内に表示するように設定
