### PR TITLE
ヘッダーのメニュートグルの幅を広げる

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -25,7 +25,7 @@
       <li><%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete } %></li>
       <li>
         <details class="relative">
-          <summary class="cursor-pointer">
+          <summary class="cursor-pointer w-48">
             メニュー
           </summary>
           <ul class="p-2 bg-base-100 rounded-t-none absolute right-0 top-full mt-1 shadow-lg z-50">


### PR DESCRIPTION
- [ ] ヘッダーのメニュートグルに関して、文字の折り返しが発生しないように幅を調整