### PR TITLE
.rubocop.ymlの中身の修正・指摘された文法の修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,218 @@
 inherit_from: .rubocop_todo.yml
+
+require:
+  - rubocop-rails
+  - rubocop-performance
+  - rubocop-rspec
+  - rubocop-capybara
+
+AllCops:
+  NewCops: enable
+  SuggestExtensions: false
+  Exclude:
+    - 'bin/**/*'
+    - 'vendor/**/*'
+    - 'db/**/*'
+    - 'spec/**/*'
+    - 'node_modules/**/*'
+    - 'config/**/*'
+    - 'config.ru'
+    - 'Gemfile'
+    - 'Rakefile'
+  DisplayCopNames: true
+
+Layout/MultilineBlockLayout:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+
+Layout/LineLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Max: 30
+
+Metrics/BlockLength:
+  Max: 30
+  Exclude:
+    - 'Gemfile'
+    - 'config/**/*'
+    - 'spec/**/*_spec.rb'
+
+Metrics/ClassLength:
+  CountComments: false
+  Max: 300
+
+Metrics/CyclomaticComplexity:
+  Max: 30
+
+Metrics/MethodLength:
+  CountComments: false
+  Max: 30
+
+Naming/AccessorMethodName:
+  Exclude:
+    - 'app/controllers/**/*'
+
+Style/AsciiComments:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/WhileUntilModifier:
+  Enabled: false
+
+Style/HashEachMethods:
+  Enabled: false
+
+Style/HashTransformKeys:
+  Enabled: false
+
+Style/HashTransformValues:
+  Enabled: false
+
+Bundler/OrderedGems:
+  Enabled: false
+
+Rails/HelperInstanceVariable:
+  Enabled: false
+
+Gemspec/DeprecatedAttributeAssignment: 
+  Enabled: false
+Gemspec/RequireMFA: 
+  Enabled: false
+Layout/LineContinuationLeadingSpace: 
+  Enabled: false
+Layout/LineContinuationSpacing: 
+  Enabled: false
+Layout/LineEndStringConcatenationIndentation: 
+  Enabled: false
+Layout/SpaceBeforeBrackets: 
+  Enabled: false
+Lint/AmbiguousAssignment: 
+  Enabled: false
+Lint/AmbiguousOperatorPrecedence: 
+  Enabled: false
+Lint/AmbiguousRange: 
+  Enabled: false
+Lint/ConstantOverwrittenInRescue: 
+  Enabled: false
+Lint/DeprecatedConstants: 
+  Enabled: false
+Lint/DuplicateBranch: 
+  Enabled: false
+Lint/DuplicateRegexpCharacterClassElement: 
+  Enabled: false
+Lint/EmptyBlock: 
+  Enabled: false
+Lint/EmptyClass: 
+  Enabled: false
+Lint/EmptyInPattern: 
+  Enabled: false
+Lint/IncompatibleIoSelectWithFiberScheduler: 
+  Enabled: false
+Lint/LambdaWithoutLiteralBlock: 
+  Enabled: false
+Lint/NoReturnInBeginEndBlocks: 
+  Enabled: false
+Lint/NonAtomicFileOperation: 
+  Enabled: false
+Lint/NumberedParameterAssignment: 
+  Enabled: false
+Lint/OrAssignmentToConstant: 
+  Enabled: false
+Lint/RedundantDirGlobSort: 
+  Enabled: false
+Lint/RefinementImportMethods: 
+  Enabled: false
+Lint/RequireRelativeSelfPath: 
+  Enabled: false
+Lint/SymbolConversion: 
+  Enabled: false
+Lint/ToEnumArguments: 
+  Enabled: false
+Lint/TripleQuotes: 
+  Enabled: false
+Lint/UnexpectedBlockArity: 
+  Enabled: false
+Lint/UnmodifiedReduceAccumulator: 
+  Enabled: false
+Lint/UselessRuby2Keywords: 
+  Enabled: false
+Naming/BlockForwarding: 
+  Enabled: false
+Security/CompoundHash: 
+  Enabled: false
+Security/IoMethods: 
+  Enabled: false
+Style/ArgumentsForwarding: 
+  Enabled: false
+Style/CollectionCompact: 
+  Enabled: false
+Style/DocumentDynamicEvalDefinition: 
+  Enabled: false
+Style/EndlessMethod: 
+  Enabled: false
+Style/EnvHome: 
+  Enabled: false
+Style/FetchEnvVar: 
+  Enabled: false
+Style/FileRead: 
+  Enabled: false
+Style/FileWrite: 
+  Enabled: false
+Style/HashConversion: 
+  Enabled: false
+Style/HashExcept: 
+  Enabled: false
+Style/IfWithBooleanLiteralBranches: 
+  Enabled: false
+Style/InPatternThen: 
+  Enabled: false
+Style/MapCompactWithConditionalBlock: 
+  Enabled: false
+Style/MapToHash: 
+  Enabled: false
+Style/MultilineInPatternThen:
+  Enabled: false
+Style/NegatedIfElseCondition: 
+  Enabled: false
+Style/NestedFileDirname: 
+  Enabled: false
+Style/NilLambda: 
+  Enabled: false
+Style/NumberedParameters: 
+  Enabled: false
+Style/NumberedParametersLimit: 
+  Enabled: false
+Style/ObjectThen: 
+  Enabled: false
+Style/OpenStructUse: 
+  Enabled: false
+Style/QuotedSymbols: 
+  Enabled: false
+Style/RedundantArgument: 
+  Enabled: false
+Style/RedundantInitialize: 
+  Enabled: false
+Style/RedundantSelfAssignmentBranch: 
+  Enabled: false
+Style/SelectByRegexp: 
+  Enabled: false
+Style/StringChars: 
+  Enabled: false
+Style/SwapValues: 
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,10 +1,2 @@
-AllCops:
-  NewCops: enable
-  Exclude:
-    - 'bin/**/*'
-    - 'db/migrate/**/*'
-    - 'db/schema.rb'
-
-require:
-  - rubocop-rails
-  - rubocop-capybara
+Rails/I18nLocaleTexts:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -83,8 +83,10 @@ end
 
 # lintチェック
 gem 'rubocop', require: false
-gem 'rubocop-capybara', require: false
 gem 'rubocop-rails', require: false
+gem "rubocop-performance", require: false
+gem "rubocop-rspec", require: false
+gem 'rubocop-capybara', require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,11 +321,16 @@ GEM
       parser (>= 3.3.1.0)
     rubocop-capybara (2.21.0)
       rubocop (~> 1.41)
+    rubocop-performance (1.22.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
     rubocop-rails (2.25.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rspec (3.1.0)
+      rubocop (~> 1.61)
     ruby-openai (7.0.1)
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
@@ -419,7 +424,9 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-capybara
+  rubocop-performance
   rubocop-rails
+  rubocop-rspec
   ruby-openai
   selenium-webdriver
   simplecov

--- a/app/controllers/personal_summaries_controller.rb
+++ b/app/controllers/personal_summaries_controller.rb
@@ -34,7 +34,7 @@ class PersonalSummariesController < ApplicationController
                  current_user.summaries.new(title: summary_params[:title], content: summary_params[:content],
                                             summary: summary_text, user: current_user)
                elsif params[:commit] == 'そのまま保存'
-                current_user.summaries.new(title: summary_params[:title], content: input_content,
+                 current_user.summaries.new(title: summary_params[:title], content: input_content,
                                             summary: nil, user: current_user)
                end
     @summary.group_id = nil if params[:summary][:group_id].blank?

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -17,12 +17,6 @@ class ProfilesController < ApplicationController
   end
 
   def destroy
-    user = @user
-    user.destroy!
-    redirect_to root_path, status: :see_other, alert: 'ユーザーが削除されました'
-  end
-
-  def destroy
     if current_user.groups.exists?(owner_id: current_user.id)
       redirect_to profile_path, alert: '自分がオーナーのグループがあります。ユーザー削除をするためには、バンドメンバーに確認の上、自分がオーナーのグループを全て削除してから実行してください。'
     else

--- a/app/controllers/tries_controller.rb
+++ b/app/controllers/tries_controller.rb
@@ -1,6 +1,6 @@
 class TriesController < ApplicationController
   skip_before_action :require_login
-  
+
   def spot; end
   def voice; end
   def summary_new; end

--- a/test/controllers/tries_controller_test.rb
+++ b/test/controllers/tries_controller_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class TriesControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'simplecov'
 SimpleCov.start 'rails'
 


### PR DESCRIPTION
- [ ] rubocoop関連のgemを、下記の種類に調整
　- [ ] gem 'rubocop', require: false
　- [ ] gem 'rubocop-rails', require: false
　- [ ] gem "rubocop-performance", require: false
　- [ ] gem "rubocop-rspec", require: false
　- [ ] gem 'rubocop-capybara', require: false

- [ ] .rubocop.yml、.rubocop_todo.ymlの中身を調整し、lintチェックの除外部分を設定
- [ ] 設定後、指摘された部分を修正